### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
      build:
        context: ./
      restart: unless-stopped
+     extra_hosts:
+           - "api.wordpress.org:66.155.40.203"
      expose:
            - "443"
      volumes:


### PR DESCRIPTION
When behind proxy, the theme function doesn't work throwing the error: https://github.com/evertramos/wordpress-docker-letsencrypt/issues/3#issuecomment-330257104 
Increasing the request timeout for api.wordpress.org can also be done in functions.php with following code:
```
// increase `timeout` for `api.wordpress.org` requests
add_filter( 'http_request_args', function( $request, $url ) {
 
    if ( strpos( $url, '://api.wordpress.org/' ) !== false ) {
        $request[ 'timeout' ] = 15;
    }
 
    return $request;
 
}, 10, 2 );
```
or adding DNS of api.wordpress.com to /etc/hosts file.